### PR TITLE
JSON VIEW - Status - Index

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -1,8 +1,13 @@
 class StatusesController < ApplicationController
   before_action :set_status, only: %i[edit update show destroy]
 
+  rescue_from ActiveRecord::RecordNotFound, with: :show_errors
+
   def index
-    @statuses = Status.where(replied_to_status_id: nil).includes(:user, :replies)
+    respond_to do |format|
+      format.html { @statuses = Status.where(replied_to_status_id: nil).includes(:user, :replies) }
+      format.json { @statuses = Status.includes(:user) }
+    end
   end
 
   def new
@@ -45,6 +50,13 @@ class StatusesController < ApplicationController
 
   def set_status
     @status = Status.find(params[:id])
+  end
+
+  def show_errors
+    respond_to do |format|
+      format.html { render file: "#{Rails.root}/public/404.html", layout: false }
+      format.json { render json: { 'error': 'Record not Found!' }, status: :not_found }
+    end
   end
 
   def status_params

--- a/app/views/statuses/index.json.jbuilder
+++ b/app/views/statuses/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.statuses @statuses.each do |status|
+  json.id status.id
+  json.body status.body.length > 150 ? status.body[0...150] + '...' : status.body
+  json.full_body status.body unless status.body.length <= 150
+  json.display_name status.user.display_name
+  json.reply_peep true if status.replied_to_status_id
+end

--- a/public/404.html
+++ b/public/404.html
@@ -1,67 +1,185 @@
-<!DOCTYPE html>
 <html>
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+    <style>
+        @import url('https://fonts.googleapis.com/css?family=Montserrat:400,600,700');
+        @import url('https://fonts.googleapis.com/css?family=Catamaran:400,800');
+        .error-container {
+        text-align: center;
+        font-size: 180px;
+        font-family: 'Catamaran', sans-serif;
+        font-weight: 800;
+        margin: 20px 15px;
+        }
+        .error-container > span {
+        display: inline-block;
+        line-height: 0.7;
+        position: relative;
+        color: #FFB485;
+        }
+        .error-container > span {
+        display: inline-block;
+        position: relative;
+        vertical-align: middle;
+        }
+        .error-container > span:nth-of-type(1) {
+        color: #D1F2A5;
+        animation: colordancing 4s infinite;
+        }
+        .error-container > span:nth-of-type(3) {
+        color: #F56991;
+        animation: colordancing2 4s infinite;
+        }
+        .error-container > span:nth-of-type(2) {
+        width: 120px;
+        height: 120px;
+        border-radius: 999px;
+        }
+        .error-container > span:nth-of-type(2):before,
+        .error-container > span:nth-of-type(2):after {
+            border-radius: 0%;
+            content:"";
+            position: absolute;
+            top: 0; left: 0;
+            width: inherit; height: inherit;
+        border-radius: 999px;
+            box-shadow: inset 30px 0 0 rgba(209, 242, 165, 0.4),
+                        inset 0 30px 0 rgba(239, 250, 180, 0.4),
+                        inset -30px 0 0 rgba(255, 196, 140, 0.4),	
+                        inset 0 -30px 0 rgba(245, 105, 145, 0.4);
+        animation: shadowsdancing 4s infinite;
+        }
+        .error-container > span:nth-of-type(2):before {
+            -webkit-transform: rotate(45deg);
+            -moz-transform: rotate(45deg);
+                    transform: rotate(45deg);
+        }
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+        .screen-reader-text {
+            position: absolute;
+            top: -9999em;
+            left: -9999em;
+        }
+        @keyframes shadowsdancing {
+        0% {
+            box-shadow: inset 30px 0 0 rgba(209, 242, 165, 0.4),
+                        inset 0 30px 0 rgba(239, 250, 180, 0.4),
+                        inset -30px 0 0 rgba(255, 196, 140, 0.4),	
+                        inset 0 -30px 0 rgba(245, 105, 145, 0.4);
+        }
+        25% {
+            box-shadow: inset 30px 0 0 rgba(245, 105, 145, 0.4),
+                        inset 0 30px 0 rgba(209, 242, 165, 0.4),
+                        inset -30px 0 0 rgba(239, 250, 180, 0.4),	
+                        inset 0 -30px 0 rgba(255, 196, 140, 0.4);
+        }
+        50% {
+            box-shadow: inset 30px 0 0 rgba(255, 196, 140, 0.4),
+                        inset 0 30px 0 rgba(245, 105, 145, 0.4),
+                        inset -30px 0 0 rgba(209, 242, 165, 0.4),	
+                        inset 0 -30px 0 rgba(239, 250, 180, 0.4);
+        }
+        75% {
+        box-shadow: inset 30px 0 0 rgba(239, 250, 180, 0.4),
+                        inset 0 30px 0 rgba(255, 196, 140, 0.4),
+                        inset -30px 0 0 rgba(245, 105, 145, 0.4),	
+                        inset 0 -30px 0 rgba(209, 242, 165, 0.4);
+        }
+        100% {
+            box-shadow: inset 30px 0 0 rgba(209, 242, 165, 0.4),
+                        inset 0 30px 0 rgba(239, 250, 180, 0.4),
+                        inset -30px 0 0 rgba(255, 196, 140, 0.4),	
+                        inset 0 -30px 0 rgba(245, 105, 145, 0.4);
+        }
+        }
+        @keyframes colordancing {
+        0% {
+            color: #D1F2A5;
+        }
+        25% {
+            color: #F56991;
+        }
+        50% {
+            color: #FFC48C;
+        }
+        75% {
+            color: #EFFAB4;
+        }
+        100% {
+            color: #D1F2A5;
+        }
+        }
+        @keyframes colordancing2 {
+        0% {
+            color: #FFC48C;
+        }
+        25% {
+            color: #EFFAB4;
+        }
+        50% {
+            color: #D1F2A5;
+        }
+        75% {
+            color: #F56991;
+        }
+        100% {
+            color: #FFC48C;
+        }
+        }
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
+        /* demo stuff */
+        * {
+            -webkit-box-sizing: border-box;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+        }
+        body {
+        background-color: #416475;
+        margin-bottom: 50px;
+        }
+        html, button, input, select, textarea {
+            font-family: 'Montserrat', Helvetica, sans-serif;
+            color: #92a4ad;
+        }
+        h1 {
+        text-align: center;
+        margin: 30px 15px;
+        }
+        .zoom-area { 
+        max-width: 490px;
+        margin: 30px auto 30px;
+        font-size: 19px;
+        text-align: center;
+        }
+        .link-container {
+        text-align: center;
+        }
+        a.more-link {
+        text-transform: uppercase;
+        font-size: 13px;
+            background-color: #92a4ad;
+            padding: 10px 15px;
+            border-radius: 0;
+            color: #416475;
+            display: inline-block;
+            margin-right: 5px;
+            margin-bottom: 5px;
+            line-height: 1.5;
+            text-decoration: none;
+        margin-top: 50px;
+        letter-spacing: 1px;
+        }
+    </style>
 </head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+<body>    
+    <section class="error-container">
+    <span>4</span>
+    <span><span class="screen-reader-text">0</span></span>
+    <span>4</span>
+    </section>
+    <h1>Not Found</h1>
+    <!-- <p class="zoom-area"><b>CSS</b> animations to make a cool 404 page. </p> -->
+    <div class="link-container">
+    <a href="http://localhost:3000" class="more-link">Back to Index</a>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
 </body>
 </html>

--- a/spec/controllers/statuses_spec.rb
+++ b/spec/controllers/statuses_spec.rb
@@ -1,0 +1,81 @@
+# rubocop:disable Metrics/BlockLength
+
+require 'rails_helper'
+
+RSpec.describe StatusesController, type: :controller do
+  describe 'GET index' do
+    render_views
+
+    it 'returns http success' do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+
+    context 'when requesting page as JSON' do
+      before { request.headers['Accept'] = 'application/json' }
+
+      it 'renders as JSON' do
+        get :index
+        expect(response.body).to be_json
+      end
+
+      context 'when database has no records' do
+        it 'returns an empty JSON object' do
+          get :index
+          expect(response.body).to be_json.with_content({})
+        end
+      end
+
+      context 'when database has saved status' do
+        it 'exhibits the saved status information in the JSON format with the owner user display name' do
+          user = double(User, display_name: 'valid_name')
+          status = double(Status, id: 4, body: 'valid_body', user: user, replied_to_status_id: nil)
+          allow(Status).to receive(:includes).and_return([status])
+
+          get :index
+          expect(response.body)
+            .to be_json
+            .with_content(
+              id: status.id,
+              body: status.body,
+              display_name: status.user.display_name
+            )
+            .at_path('statuses.0')
+        end
+
+        context 'when the status is a reply for another status' do
+          let(:reply_status) { build_stubbed(:status, replied_to_status: status) }
+          let(:status) { build_stubbed(:status) }
+
+          it "has an additional key 'reply_peep'" do
+            allow(Status).to receive(:includes).and_return([status, reply_status])
+
+            get :index
+            parsed_body = JSON.parse(response.body)
+            expect(parsed_body['statuses']).to include(
+              include('reply_peep' => true)
+            )
+          end
+        end
+
+        context 'when the status body field has more than 150 characters' do
+          let(:long_body_status) { build_stubbed(:status_with_long_body) }
+
+          it 'exhibits the first 150 characters' do
+            allow(Status).to receive(:includes).and_return([long_body_status])
+
+            get :index
+            expect(response.body).to be_json.with_content("#{long_body_status.body[0...150]}...").at_path('statuses.0.body')
+          end
+
+          it "creates a new field named 'full_body' with the whole message" do
+            allow(Status).to receive(:includes).and_return([long_body_status])
+
+            get :index
+            expect(response.body).to be_json.with_content(long_body_status.body).at_path('statuses.0.full_body')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/statuses.rb
+++ b/spec/factories/statuses.rb
@@ -1,13 +1,24 @@
+require 'ffaker'
+
 FactoryBot.define do
-  factory :status do
-    body { "Whatever status you would want" }
+  factory :status, aliases: [:replied_to_status] do
+    body { 'Valid body' }
+    # association :user, factory: :user
+    user
 
-    transient do
-      media {[]}
+    trait :with_reply do
+      replied_to_status
     end
 
-    after(:create) do |status, data|
-      status.media << data.media
+    trait :with_long_body do
+      body { 's' * 300 }
     end
+
+    factory :status_with_replies do
+      replies { [association(:replied_status)] }
+    end
+
+    factory :replied_status, traits: [:with_reply]
+    factory :status_with_long_body, traits: [:with_long_body]
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,10 @@
+require 'ffaker'
+
+FactoryBot.define do
+  factory :user do
+    display_name { FFaker::Name.name }
+    handle       { FFaker::String.unique.from_regexp(/[a-z]{4,12}/) }
+    bio          { 'valid_bio' }
+    born_at      { 14.years.ago }
+  end
+end


### PR DESCRIPTION
## Description

This PR makes possible for the client to request `statuses` route with a GET request with header `Accept: application/json` and returns the statuses data from database in JSON format.

This also concludes the task 1 of 3 from [@GabrielRMuller Week 6 Challenge](https://gist.github.com/GabrielRMuller/fb8633a36f1b9f84b5294dd965836483).

## How was this tested?

The status controller file was tested with `controller` tests using `rspec-json_matches 0.1.0` gem to help getting json values from the view

## Checklist
- [x] Must show status `body` property
- [x] If `body` is bigger than 150 characters, cut the message, add reticences and display a new property named `full_body` with the whole content
- [x] Must show the `display_name` from the user owner of the status
- [x] If the status is a reply from another status, must show the property `reply_peep` 