### PR TITLE
JSON VIEW - Status - Show

### DIFF
--- a/app/views/statuses/show.json.jbuilder
+++ b/app/views/statuses/show.json.jbuilder
@@ -1,0 +1,6 @@
+json.status do
+  json.body @status.body
+  json.display_name @status.user.display_name
+  json.reply_peep true if @status.replied_to_status_id.present?
+  json.media @status.media.length # (@status.media.filter { |m| m if m.url.present? }).length
+end

--- a/spec/factories/medium.rb
+++ b/spec/factories/medium.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :medium do
+    kind { 0 }
+    url { 'https://via.placeholder.com/150' }
+    status
+  end
+end

--- a/spec/factories/statuses.rb
+++ b/spec/factories/statuses.rb
@@ -18,6 +18,15 @@ FactoryBot.define do
       replies { [association(:replied_status)] }
     end
 
+    factory :status_with_media do
+      transient do
+        medium_count { 2 }
+      end
+      after(:create) do |status, evaluator|
+        create_list(:medium, evaluator.medium_count, status: status)
+      end
+    end
+
     factory :replied_status, traits: [:with_reply]
     factory :status_with_long_body, traits: [:with_long_body]
   end


### PR DESCRIPTION
## Description

This PR makes possible for the client to request to the `statuses/:id` route with a GET request with header Accept: application/json and returns a specific data from database in JSON format.

This also concludes the task 2 of 3 from [@GabrielRMuller Week 6 Challenge](https://gist.github.com/GabrielRMuller/fb8633a36f1b9f84b5294dd965836483).

## How was this tested?

The status controller file was tested with controller tests using `rspec-json_matches 0.1.0` gem to help getting json values from the view

## Checklist

- [x] Must show the whole `body` property
- [x] Must show `display_name` property of the user owner of the status
- [x] If it is a reply, exhibits `reply_peep`key as `true`
- [x] Must show the amount of `media` objects attached it has
